### PR TITLE
Switched from Nil to Nobody SID due to mismatch on 2012R2

### DIFF
--- a/controls/03_user_rights_spec.rb
+++ b/controls/03_user_rights_spec.rb
@@ -16,7 +16,7 @@ control 'cis-network-access-2.2.2' do
   title '2.2.2 Set Access this computer from the network'
   desc 'Set Access this computer from the network'
   describe security_policy do
-    its('SeNetworkLogonRight') { should eq ['S-1-0'] }
+    its('SeNetworkLogonRight') { should eq ['S-1-0-0'] }
   end
 end
 


### PR DESCRIPTION
Guidance on SID mismatch suggests using Nobody SID over Null. Updated control appropriately. Confirmed working on 2012R2.