### PR TITLE
Removed per control licensing as repo is under Apache 2.0

### DIFF
--- a/controls/04_audit_spec.rb
+++ b/controls/04_audit_spec.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# copyright: 2015, Chef Software, Inc
-# license: All rights reserved
 
 title 'Windows Audit & Logging Configuration'
 

--- a/controls/05_ie_spec.rb
+++ b/controls/05_ie_spec.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# copyright: 2015, Chef Software, Inc
-# license: All rights reserved
 
 title 'Windows IE Configuration'
 

--- a/controls/07_rdp_spec.rb
+++ b/controls/07_rdp_spec.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# copyright: 2015, Chef Software, Inc
-# license: All rights reserved
 
 title 'Windows RDP Configuration'
 

--- a/controls/08_access_spec.rb
+++ b/controls/08_access_spec.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# copyright: 2015, Chef Software, Inc
-# license: All rights reserved
 
 title 'Windows Access Configuration'
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,6 +7,6 @@ copyright: Hardening Framework Team
 copyright_email: hello@hardening.io
 license: Apache 2 license
 summary: Baselin for best-preactice Windows OS hardening
-version: 1.0.0
+version: 1.0.1
 supports:
   - os-family: windows


### PR DESCRIPTION
Removed per control file licensing as the repo is under Apache 2.0 as described here: https://github.com/dev-sec/windows-baseline/blob/joeg/licenseChange/LICENSE

Addresses #4 