### PR TITLE
fixing control for 'cis-access-cred-manager-2.2.1'

### DIFF
--- a/controls/user_rights.rb
+++ b/controls/user_rights.rb
@@ -7,7 +7,7 @@ control 'cis-access-cred-manager-2.2.1' do
   title '2.2.1 Set Access Credential Manager as a trusted caller to No One'
   desc 'Set Access Credential Manager as a trusted caller to No One'
   describe security_policy do
-    its('SeTrustedCredManAccessPrivilege') { should eq ['S-1-0-0'] }
+    its('SeTrustedCredManAccessPrivilege') { should eq [] }
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,6 +7,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache 2 license
 summary: Baseline for best-practice Windows OS hardening
-version: 1.1.1
+version: 1.1.2
 supports:
   - os-family: windows


### PR DESCRIPTION
The 'SeTrustedCredManAccessPrivilege' should be granted to 'No One' instead of the Nobody 'S-1-0-0' well-known-SID.
It should be checked for an empty list for this access right which usually is already covered by the default configuration of Windows.

Please see also https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/access-credential-manager-as-a-trusted-caller

Signed-off-by: Werner Kraus <werner@scerus.com>