### PR TITLE
Bump version to 1.1.3 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**/.librarian
+**/Puppetfile.lock
+**/.tmp
+Gemfile.lock
+Berksfile.lock
+inspec.lock
+nbproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.0.0](https://github.com/dev-sec/windows-baseline/tree/2.0.0) (2019-04-27)
+[Full Changelog](https://github.com/dev-sec/windows-baseline/compare/1.1.2...2.0.0)
+
+**Merged pull requests:**
+
+- Update common [\#26](https://github.com/dev-sec/windows-baseline/pull/26) ([atomic111](https://github.com/atomic111))
+
 ## [1.1.2](https://github.com/dev-sec/windows-baseline/tree/1.1.2) (2019-03-26)
 [Full Changelog](https://github.com/dev-sec/windows-baseline/compare/1.1.0...1.1.2)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 2.0.1'
+gem 'highline', '~> 2.0.2'
 gem 'inspec', '~> 3'
-gem 'rack', '2.0.6'
-gem 'rake'
-gem 'rubocop', '~> 0.66.0'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,23 +17,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with s`rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'windows-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,6 +7,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache 2 license
 summary: Baseline for best-practice Windows OS hardening
-version: 1.1.2
+version: 1.1.3
 supports:
   - os-family: windows


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:
```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```