### PR TITLE
Fixes comparisons when registry key data type are REG_SZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ We use a yml attribute file to steer the configuration, the following options ar
   * `se_restore_privilege`
     define which users are allowed to restore files and directories
 
-  * `hklm_null_session_pipes`
-    define named pipes that can be accessed anonymously
-
 ## Usage
 
 InSpec makes it easy to run your tests wherever you need. More options listed here: [InSpec cli](http://inspec.io/docs/reference/cli/)

--- a/controls/administrative_templates_computer.rb
+++ b/controls/administrative_templates_computer.rb
@@ -662,7 +662,7 @@ control 'windows-200' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
     it { should have_property 'ScreenSaverGracePeriod' }
-    its('ScreenSaverGracePeriod') { should be <= 5 }
+    its('ScreenSaverGracePeriod') { should cmp <= 5 }
   end
 end
 

--- a/controls/administrative_templates_computer.rb
+++ b/controls/administrative_templates_computer.rb
@@ -474,7 +474,7 @@ control 'windows-192' do
   describe registry_key('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
     it { should have_property 'AutoAdminLogon' }
-    its('AutoAdminLogon') { should cmp == 0 }
+    its('AutoAdminLogon') { should cmp 0 }
   end
 end
 

--- a/controls/administrative_templates_computer.rb
+++ b/controls/administrative_templates_computer.rb
@@ -474,7 +474,7 @@ control 'windows-192' do
   describe registry_key('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
     it { should have_property 'AutoAdminLogon' }
-    its('AutoAdminLogon') { should eq 0 }
+    its('AutoAdminLogon') { should cmp == 0 }
   end
 end
 

--- a/controls/administrative_templates_computer.rb
+++ b/controls/administrative_templates_computer.rb
@@ -2970,7 +2970,7 @@ control 'windows-289' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Application') do
     it { should exist }
     it { should have_property 'Retention' }
-    its('Retention') { should eq 0 }
+    its('Retention') { should cmp 0 }
   end
 end
 
@@ -3014,7 +3014,7 @@ control 'windows-291' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Security') do
     it { should exist }
     it { should have_property 'Retention' }
-    its('Retention') { should eq 0 }
+    its('Retention') { should cmp 0 }
   end
 end
 
@@ -3058,7 +3058,7 @@ control 'windows-293' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Setup') do
     it { should exist }
     it { should have_property 'Retention' }
-    its('Retention') { should eq 0 }
+    its('Retention') { should cmp 0 }
   end
 end
 
@@ -3102,7 +3102,7 @@ control 'windows-295' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\System') do
     it { should exist }
     it { should have_property 'Retention' }
-    its('Retention') { should eq 0 }
+    its('Retention') { should cmp 0 }
   end
 end
 
@@ -3968,19 +3968,19 @@ control 'windows-331' do
   describe registry_key('HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules') do
     it { should exist }
     it { should have_property '75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84' }
-    its('75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84') { should eq 1 }
+    its('75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84') { should cmp 1 }
     it { should have_property '3b576869-a4ec-4529-8536-b80a7769e899' }
-    its('3b576869-a4ec-4529-8536-b80a7769e899') { should eq 1 }
+    its('3b576869-a4ec-4529-8536-b80a7769e899') { should cmp 1 }
     it { should have_property 'd4f940ab-401b-4efc-aadc-ad5f3c50688a' }
-    its('d4f940ab-401b-4efc-aadc-ad5f3c50688a') { should eq 1 }
+    its('d4f940ab-401b-4efc-aadc-ad5f3c50688a') { should cmp 1 }
     it { should have_property '92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b' }
-    its('92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b') { should eq 1 }
+    its('92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b') { should cmp 1 }
     it { should have_property '5beb7efe-fd9a-4556-801d-275e5ffc04cc' }
-    its('5beb7efe-fd9a-4556-801d-275e5ffc04cc') { should eq 1 }
+    its('5beb7efe-fd9a-4556-801d-275e5ffc04cc') { should cmp 1 }
     it { should have_property 'd3e037e1-3eb8-44c8-a917-57927947596d' }
-    its('d3e037e1-3eb8-44c8-a917-57927947596d') { should eq 1 }
+    its('d3e037e1-3eb8-44c8-a917-57927947596d') { should cmp 1 }
     it { should have_property 'be9ba2d9-53ea-4cdc-84e5-9b1eeee46550' }
-    its('be9ba2d9-53ea-4cdc-84e5-9b1eeee46550') { should eq 1 }
+    its('be9ba2d9-53ea-4cdc-84e5-9b1eeee46550') { should cmp 1 }
   end
 end
 

--- a/controls/administrative_templates_user.rb
+++ b/controls/administrative_templates_user.rb
@@ -19,7 +19,7 @@ control 'windows-360' do
     describe registry_key(entry) do
       it { should exist }
       it { should have_property 'ScreenSaveActive' }
-      its('ScreenSaveActive') { should eq 1 }
+      its('ScreenSaveActive') { should cmp == 1 }
     end
   end
 end
@@ -67,7 +67,7 @@ control 'windows-362' do
     describe registry_key(entry) do
       it { should exist }
       it { should have_property 'ScreenSaverIsSecure' }
-      its('ScreenSaverIsSecure') { should eq 1 }
+      its('ScreenSaverIsSecure') { should cmp == 1 }
     end
   end
 end

--- a/controls/administrative_templates_user.rb
+++ b/controls/administrative_templates_user.rb
@@ -19,7 +19,7 @@ control 'windows-360' do
     describe registry_key(entry) do
       it { should exist }
       it { should have_property 'ScreenSaveActive' }
-      its('ScreenSaveActive') { should cmp == 1 }
+      its('ScreenSaveActive') { should cmp 1 }
     end
   end
 end
@@ -67,7 +67,7 @@ control 'windows-362' do
     describe registry_key(entry) do
       it { should exist }
       it { should have_property 'ScreenSaverIsSecure' }
-      its('ScreenSaverIsSecure') { should cmp == 1 }
+      its('ScreenSaverIsSecure') { should cmp 1 }
     end
   end
 end

--- a/controls/local_policies.rb
+++ b/controls/local_policies.rb
@@ -1089,7 +1089,7 @@ control 'windows-058' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
     it { should have_property 'AllocateDASD' }
-    its('AllocateDASD') { should eq 0 }
+    its('AllocateDASD') { should cmp == 0 }
   end
 end
 
@@ -1472,7 +1472,7 @@ control 'windows-074' do
   end
   describe registry_key('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
-    its('CachedLogonsCount') { should be <= 4 }
+    its('CachedLogonsCount') { should cmp <= 4 }
   end
 end
 

--- a/controls/local_policies.rb
+++ b/controls/local_policies.rb
@@ -1897,7 +1897,7 @@ control 'windows-091' do
   describe registry_key('HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters') do
     it { should exist }
     it { should have_property 'NullSessionPipes' }
-    its('NullSessionPipes') { should eq([]).or eq([""]) }
+    its('NullSessionPipes') { should eq([]).or eq(['']) }
   end
 end
 

--- a/controls/local_policies.rb
+++ b/controls/local_policies.rb
@@ -1897,7 +1897,7 @@ control 'windows-091' do
   describe registry_key('HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters') do
     it { should exist }
     it { should have_property 'NullSessionPipes' }
-    its('NullSessionPipes') { should eq attribute('hklm_null_session_pipes') }
+    its('NullSessionPipes') { should eq([]).or eq([""]) }
   end
 end
 

--- a/controls/local_policies.rb
+++ b/controls/local_policies.rb
@@ -1089,7 +1089,7 @@ control 'windows-058' do
   describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
     it { should exist }
     it { should have_property 'AllocateDASD' }
-    its('AllocateDASD') { should cmp == 0 }
+    its('AllocateDASD') { should cmp 0 }
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -110,8 +110,3 @@ attributes:
       description: 'define which users are allowed to restore files and directories'
       value: ['S-1-5-32-544']
       type: array
-    - name: hklm_null_session_pipes
-      required: false
-      description: 'define named pipes that can be accessed anonymously'
-      value: []
-      type: array


### PR DESCRIPTION
Fixes #45 

Revised all the REG_SZ with integer values and changed to `cmp`.

Now returns are like:

```rb
✔  Registry Key XXX is expected to cmp <= 4
```