### PR TITLE
Revert lint breaking .positive

### DIFF
--- a/controls/account_policies.rb
+++ b/controls/account_policies.rb
@@ -45,7 +45,7 @@ control 'windows-002' do
     its('MaximumPasswordAge') { should be <= input('maximum_password_age') }
   end
   describe security_policy do
-    its('MaximumPasswordAge') { should be.positive? }
+    its('MaximumPasswordAge') { should be > 0 }
   end
 end
 
@@ -178,7 +178,7 @@ control 'windows-008' do
     its('LockoutBadCount') { should be <= 10 }
   end
   describe security_policy do
-    its('LockoutBadCount') { should be.positive? }
+    its('LockoutBadCount') { should be > 0 }
   end
 end
 


### PR DESCRIPTION
Fixes issue #59 

PR https://github.com/dev-sec/windows-baseline/pull/50 introduced a regression since the `RSpec::Matchers::DSL::Matcher cmp` class does not have a `.positive` method. 