### PR TITLE
Fix local_policies 'no such value .positive?'

### DIFF
--- a/controls/local_policies.rb
+++ b/controls/local_policies.rb
@@ -1308,7 +1308,7 @@ control 'windows-067' do
   describe registry_key('HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Netlogon\\Parameters') do
     it { should exist }
     it { should have_property 'MaximumPasswordAge' }
-    its('MaximumPasswordAge') { should cmp.positive? }
+    its('MaximumPasswordAge') { should cmp > 0 }
   end
   describe registry_key('HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\Netlogon\\Parameters') do
     it { should exist }


### PR DESCRIPTION
Related to https://github.com/dev-sec/windows-baseline/pull/60/files